### PR TITLE
refactor(watchers): run watchers in dev or prod, log only in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "license": "AGPL-3.0-or-later",
   "scripts": {
     "dev": "nodemon src/index.js",
+    "dev:watchers": "DOWNLOAD_WATCHERS=true nodemon src/index.js",
     "test": "jest --watchAll",
     "test:ci": "jest",
-    "dev:watchers": "DOWNLOAD_WATCHERS=true nodemon src/index.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "download-watchers": "DOWNLOAD_WATCHERS=true node src/watchers/download-watchers.js"

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const TEMP_DIR_PATH = path.resolve(path.join('.', 'tmp'));
 
 const {
-  NODE_ENV,
+  NODE_ENV = 'development',
   DATABASE_URL,
   PORT = 3000,
   DOWNLOAD_WATCHERS = false,

--- a/src/watchers/index.js
+++ b/src/watchers/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 const { CronJob } = require('cron');
-const { WATCHERS_PATH } = require('../config');
+const { env, WATCHERS_PATH } = require('../config');
 const downloadWatchers = require('./download-watchers');
 const { loadWatchers } = require('./load-watchers');
 const { runWatchersAuth, runWatchersNoAuth } = require('./run-watchers');
@@ -36,13 +36,15 @@ async function setUpWatchers() {
     },
   );
 
-  minuteWatchersCronJob.start();
-  hourWatchersCronJob.start();
+  if (env.isProd || env.isDev) {
+    minuteWatchersCronJob.start();
+    hourWatchersCronJob.start();
 
-  console.log('minuteWatchersAuth', minuteWatchersAuth);
-  console.log('minuteWatchersNoAuth', minuteWatchersNoAuth);
-  console.log('hourWatchersAuth', hourWatchersAuth);
-  console.log('hourWatchersNoAuth', hourWatchersNoAuth);
+    console.log('minuteWatchersAuth', minuteWatchersAuth);
+    console.log('minuteWatchersNoAuth', minuteWatchersNoAuth);
+    console.log('hourWatchersAuth', hourWatchersAuth);
+    console.log('hourWatchersNoAuth', hourWatchersNoAuth);
+  }
 
   return { watchers, minuteWatchersCronJob, hourWatchersCronJob };
 }

--- a/src/watchers/run-watchers.js
+++ b/src/watchers/run-watchers.js
@@ -3,7 +3,7 @@ const util = require('util');
 const {
   constants: { TIMEFRAMES },
 } = require('@notify-watcher/core');
-const { env } = require('../../config.js');
+const { env } = require('../config.js');
 const executor = require('./executor');
 
 // Keep track of which watchers are running,

--- a/src/watchers/run-watchers.js
+++ b/src/watchers/run-watchers.js
@@ -3,6 +3,7 @@ const util = require('util');
 const {
   constants: { TIMEFRAMES },
 } = require('@notify-watcher/core');
+const { env } = require('../../config.js');
 const executor = require('./executor');
 
 // Keep track of which watchers are running,
@@ -96,8 +97,7 @@ function shouldRunWatcher({ config: { timeframe } }, runDate) {
 }
 
 function logWatcherIteration(data) {
-  // TODO: change to config.isDev when that's merged
-  if (process.env.NODE_ENV !== 'production') {
+  if (env.isDev) {
     console.log(`\n### Watcher iteration ${data.watcherName}\n`);
     console.log(util.inspect(data, { showHidden: false, depth: 2 }));
   }


### PR DESCRIPTION
Also add `NODE_ENV = 'development'` as default