### PR TITLE
feat(watchers): unired-tag watcher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - node_bootstrap
       - run: npm run test:ci
 
-  download-watchers:
+  download_watchers:
     description: Run the linter
     executor: node_executor
     steps:
@@ -67,6 +67,6 @@ workflows:
       - test:
           requires:
             - bootstrap
-      - download-watchers:
+      - download_watchers:
           requires:
             - bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,13 @@ jobs:
       - node_bootstrap
       - run: npm run test:ci
 
+  download-watchers:
+    description: Run the linter
+    executor: node_executor
+    steps:
+      - node_bootstrap
+      - run: npm run download-watchers
+
 workflows:
   version: 2
   commit:
@@ -58,5 +65,8 @@ workflows:
           requires:
             - bootstrap
       - test:
+          requires:
+            - bootstrap
+      - download-watchers:
           requires:
             - bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
     executor: node_executor
     steps:
       - node_bootstrap
-      - run: npm run download-watchers
+      - run: sudo npm run download-watchers
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "koa-router": "^7.4.0",
     "mongoose": "^5.7.4",
     "nodegit": "^0.26.2",
+    "puppeteer": "^1.20.0",
     "supertest": "^4.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "koa-router": "^7.4.0",
     "mongoose": "^5.7.4",
     "nodegit": "^0.26.2",
-    "puppeteer": "^1.20.0",
     "supertest": "^4.0.2"
   },
   "devDependencies": {

--- a/src/watchers/download-watchers.js
+++ b/src/watchers/download-watchers.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+const util = require('util');
 const fs = require('fs-extra');
 const path = require('path');
 const git = require('nodegit');
@@ -39,7 +40,7 @@ async function downloadWatchers() {
   if (!config.DOWNLOAD_WATCHERS) return;
   fs.emptyDirSync(config.WATCHERS_TEMP_PATH);
   fs.emptyDirSync(config.WATCHERS_PATH);
-  console.table(WATCHERS_LIST);
+  console.log(util.inspect(WATCHERS_LIST, { showHidden: false, depth: 2 }));
   console.log();
 
   await Promise.all(

--- a/src/watchers/index.js
+++ b/src/watchers/index.js
@@ -40,6 +40,7 @@ async function setUpWatchers() {
     minuteWatchersCronJob.start();
     hourWatchersCronJob.start();
 
+    console.log('');
     console.log('minuteWatchersAuth', minuteWatchersAuth);
     console.log('minuteWatchersNoAuth', minuteWatchersNoAuth);
     console.log('hourWatchersAuth', hourWatchersAuth);

--- a/src/watchers/list.js
+++ b/src/watchers/list.js
@@ -23,8 +23,8 @@ const ALL_WATCHERS_KEY = 'all';
 const WATCHERS_LIST = [
   {
     url: 'https://github.com/notify-watcher/watchers',
-    branch: 'master',
-    watchers: ['gtd', 'github-notifications', 'vtr'],
+    branch: 'watcher-unired-tag-total',
+    watchers: ['gtd', 'github-notifications', 'vtr', 'unired-tag'],
   },
 ];
 

--- a/src/watchers/list.js
+++ b/src/watchers/list.js
@@ -23,7 +23,7 @@ const ALL_WATCHERS_KEY = 'all';
 const WATCHERS_LIST = [
   {
     url: 'https://github.com/notify-watcher/watchers',
-    branch: 'watcher-unired-tag-total',
+    branch: 'master',
     watchers: ['gtd', 'github-notifications', 'vtr', 'unired-tag'],
   },
 ];

--- a/src/watchers/run-watchers.js
+++ b/src/watchers/run-watchers.js
@@ -24,6 +24,15 @@ const Users = [
         },
         snapshot: {},
       },
+      'unired-tag': {
+        auth: {
+          rut: process.env.RUT,
+        },
+        notificationTypes: {
+          updatedBallot: ['clientId'],
+        },
+        snapshot: {},
+      },
     },
   },
   {

--- a/src/watchers/run-watchers.js
+++ b/src/watchers/run-watchers.js
@@ -44,7 +44,9 @@ const Snapshots = [
 ];
 
 async function isRunning(id) {
-  return MOCK_REDIS[id];
+  const watcherIsRunning = MOCK_REDIS[id];
+  if (watcherIsRunning) console.log(`Watcher already running: ${id}`);
+  return watcherIsRunning;
 }
 
 async function startRunning(id) {


### PR DESCRIPTION
- Depends on notify-watcher/watchers#28
  - After it's merged `src/watchers/list.js` should be updated
- Installs `puppeteer`, if we add it to `core` it won't be necessary to be installed here
- Download watchers in CI
- Log if a watcher doesn't run because it's already running
- Update WATCHERS_LIST log
- Add a space before printing watchers that will run

Depends on #21 