### PR TITLE
refactor(mongoose): useCreateIndex option

### DIFF
--- a/src/mongoose.js
+++ b/src/mongoose.js
@@ -5,6 +5,7 @@ mongoose.Promise = global.Promise;
 
 function dbConnect(databaseUrl) {
   return mongoose.connect(databaseUrl, {
+    useCreateIndex: true,
     useNewUrlParser: true,
     useUnifiedTopology: true,
   });


### PR DESCRIPTION
To avoid

```
(node:28315) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.
```

https://mongoosejs.com/docs/deprecations.html#ensureindex